### PR TITLE
feat: add squash commits functionality

### DIFF
--- a/src/dataSource.ts
+++ b/src/dataSource.ts
@@ -1098,6 +1098,35 @@ export class DataSource extends Disposable {
 	}
 
 	/**
+	 * Squash multiple commits into one.
+	 * @param repo The path of the repository.
+	 * @param commits Array of commit hashes to squash (from newest to oldest).
+	 * @param commitMessage The commit message for the squashed commit.
+	 * @returns The ErrorInfo from the executed command.
+	 */
+	public async squashCommits(repo: string, commits: ReadonlyArray<string>, commitMessage: string): Promise<ErrorInfo> {
+		if (commits.length < 2) {
+			return 'At least 2 commits are required for squashing.';
+		}
+
+		const oldestCommit = commits[commits.length - 1];
+
+		// Reset to the parent of the oldest commit, keeping changes staged
+		const resetResult = await this.runGitCommand(['reset', '--soft', oldestCommit + '^'], repo);
+		if (resetResult !== null) {
+			return resetResult;
+		}
+
+		// Create a new commit with the combined changes
+		const commitArgs = ['commit', '-m', commitMessage];
+		if (getConfig().signCommits) {
+			commitArgs.push('-S');
+		}
+
+		return this.runGitCommand(commitArgs, repo);
+	}
+
+	/**
 	 * Reset the current branch to a specified commit.
 	 * @param repo The path of the repository.
 	 * @param commit The hash of the commit that the current branch should be reset to.

--- a/src/gitGraphView.ts
+++ b/src/gitGraphView.ts
@@ -7,7 +7,7 @@ import { ExtensionState } from './extensionState';
 import { Logger } from './logger';
 import { RepoFileWatcher } from './repoFileWatcher';
 import { RepoManager } from './repoManager';
-import { ErrorInfo, GitConfigLocation, GitGraphViewInitialState, GitPushBranchMode, GitRepoSet, LoadGitGraphViewTo, RequestMessage, ResponseMessage, TabIconColourTheme } from './types';
+import { ErrorInfo, GitConfigLocation, GitGraphViewInitialState, GitPushBranchMode, GitRepoSet, LoadGitGraphViewTo, RequestMessage, RequestSquashCommits, ResponseMessage, TabIconColourTheme } from './types';
 import { UNABLE_TO_FIND_GIT_MSG, UNCOMMITTED, archive, copyFilePathToClipboard, copyToClipboard, createPullRequest, getNonce, openExtensionSettings, openExternalUrl, openFile, showErrorMessage, viewDiff, viewDiffWithWorkingFile, viewFileAtRevision, viewScm } from './utils';
 import { Disposable, toDisposable } from './utils/disposable';
 
@@ -368,6 +368,12 @@ export class GitGraphView extends Disposable {
 				this.sendMessage({
 					command: 'dropStash',
 					error: await this.dataSource.dropStash(msg.repo, msg.selector)
+				});
+				break;
+			case 'squashCommits':
+				this.sendMessage({
+					command: 'squashCommits',
+					error: await this.dataSource.squashCommits(msg.repo, (msg as RequestSquashCommits).commits, (msg as RequestSquashCommits).commitMessage)
 				});
 				break;
 			case 'editRemote':

--- a/src/types.ts
+++ b/src/types.ts
@@ -820,6 +820,15 @@ export interface ResponseDropCommit extends ResponseWithErrorInfo {
 	readonly command: 'dropCommit';
 }
 
+export interface RequestSquashCommits extends RepoRequest {
+	readonly command: 'squashCommits';
+	readonly commits: ReadonlyArray<string>;
+	readonly commitMessage: string;
+}
+export interface ResponseSquashCommits extends ResponseWithErrorInfo {
+	readonly command: 'squashCommits';
+}
+
 export interface RequestDropStash extends RepoRequest {
 	readonly command: 'dropStash';
 	readonly selector: string;
@@ -1301,6 +1310,7 @@ export type RequestMessage =
 	| RequestRevertCommit
 	| RequestSetGlobalViewState
 	| RequestSetRepoState
+	| RequestSquashCommits
 	| RequestSetWorkspaceViewState
 	| RequestShowErrorDialog
 	| RequestStartCodeReview
@@ -1364,6 +1374,7 @@ export type ResponseMessage =
 	| ResponseRevertCommit
 	| ResponseSetGlobalViewState
 	| ResponseSetWorkspaceViewState
+	| ResponseSquashCommits
 	| ResponseStartCodeReview
 	| ResponseTagDetails
 	| ResponseUpdateCodeReview

--- a/web/main.ts
+++ b/web/main.ts
@@ -32,6 +32,7 @@ class GitGraphView {
 
 	private moreCommitsAvailable: boolean = false;
 	private expandedCommit: ExpandedCommit | null = null;
+	private selectedCommits: Set<string> = new Set();
 	private maxCommits: number;
 	private scrollTop = 0;
 	private renderedGitBranchHead: string | null = null;
@@ -774,6 +775,80 @@ class GitGraphView {
 		}
 	}
 
+	/* Multi-select Commit Management */
+
+	private toggleCommitSelection(commitHash: string, commitElem: HTMLElement) {
+		if (this.selectedCommits.has(commitHash)) {
+			this.selectedCommits.delete(commitHash);
+			commitElem.classList.remove('commitSelected');
+		} else {
+			this.selectedCommits.add(commitHash);
+			commitElem.classList.add('commitSelected');
+		}
+	}
+
+	private clearCommitSelection() {
+		const selectedElems = document.querySelectorAll('.commitSelected');
+		selectedElems.forEach(elem => elem.classList.remove('commitSelected'));
+		this.selectedCommits.clear();
+	}
+
+	private getSelectedCommitsArray(): string[] {
+		return Array.from(this.selectedCommits).sort((a, b) => {
+			const indexA = this.commitLookup[a];
+			const indexB = this.commitLookup[b];
+			return indexA - indexB;
+		});
+	}
+
+	private areSelectedCommitsContiguous(): boolean {
+		if (this.selectedCommits.size < 2) return true;
+
+		const sortedCommits = this.getSelectedCommitsArray();
+		for (let i = 0; i < sortedCommits.length - 1; i++) {
+			const currentIndex = this.commitLookup[sortedCommits[i]];
+			const nextIndex = this.commitLookup[sortedCommits[i + 1]];
+			if (nextIndex - currentIndex !== 1) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	private squashCommitsAction(target: DialogTarget & CommitTarget) {
+		const selectedCommits = this.getSelectedCommitsArray();
+		if (selectedCommits.length < 2) return;
+
+		const oldestCommit = selectedCommits[selectedCommits.length - 1];
+		const newestCommit = selectedCommits[0];
+		const oldestCommitData = this.commits[this.commitLookup[oldestCommit]];
+		const newestCommitData = this.commits[this.commitLookup[newestCommit]];
+
+		dialog.showForm(
+			`Are you sure you want to squash ${selectedCommits.length} commits into one?<br><br>` +
+			`<b>Oldest:</b> ${abbrevCommit(oldestCommit)} - ${escapeHtml(oldestCommitData.message)}<br>` +
+			`<b>Newest:</b> ${abbrevCommit(newestCommit)} - ${escapeHtml(newestCommitData.message)}`,
+			[{
+				type: DialogInputType.Text,
+				name: 'Commit Message',
+				default: newestCommitData.message,
+				placeholder: 'Enter the commit message for the squashed commit'
+			}],
+			'Yes, squash commits',
+			(values) => {
+				const commitMessage = <string>values[0];
+				runAction({
+					command: 'squashCommits',
+					repo: this.currentRepo,
+					commits: selectedCommits,
+					commitMessage: commitMessage
+				}, 'Squashing Commits');
+				this.clearCommitSelection();
+			},
+			target
+		);
+	}
+
 
 	/* Renderers */
 
@@ -1099,7 +1174,18 @@ class GitGraphView {
 	private getCommitContextMenuActions(target: DialogTarget & CommitTarget): ContextMenuActions {
 		const hash = target.hash, visibility = this.config.contextMenuActionsVisibility.commit;
 		const commit = this.commits[this.commitLookup[hash]];
-		return [[
+		let actions: ContextMenuActions = [];
+
+		// Multi-select squash option
+		if (this.selectedCommits.size > 1 && this.selectedCommits.has(hash) && this.areSelectedCommitsContiguous()) {
+			actions = [...actions, [{
+				title: 'Squash Selected Commits' + ELLIPSIS,
+				visible: true,
+				onClick: () => this.squashCommitsAction(target)
+			}]];
+		}
+
+		return [...actions, [
 			{
 				title: 'Add Tag' + ELLIPSIS,
 				visible: visibility.addTag,
@@ -2216,22 +2302,31 @@ class GitGraphView {
 
 			} else if ((eventElem = eventTarget.closest('.commit')) !== null) {
 				// .commit was clicked
-				if (this.expandedCommit !== null) {
-					const commit = this.getCommitOfElem(eventElem);
-					if (commit === null) return;
+				const commit = this.getCommitOfElem(eventElem);
+				if (commit === null) return;
 
+				const mouseEvent = <MouseEvent>e;
+
+				if (mouseEvent.shiftKey) {
+					// Shift+click: toggle commit selection for multi-select
+					this.toggleCommitSelection(commit.hash, eventElem);
+				} else if (this.expandedCommit !== null) {
 					if (this.expandedCommit.commitHash === commit.hash) {
 						this.closeCommitDetails(true);
-					} else if ((<MouseEvent>e).ctrlKey || (<MouseEvent>e).metaKey) {
+					} else if (mouseEvent.ctrlKey || mouseEvent.metaKey) {
 						if (this.expandedCommit.compareWithHash === commit.hash) {
 							this.closeCommitComparison(true);
 						} else if (this.expandedCommit.commitElem !== null) {
 							this.loadCommitComparison(this.expandedCommit.commitElem, eventElem);
 						}
 					} else {
+						// Clear selection when clicking normally
+						this.clearCommitSelection();
 						this.loadCommitDetails(eventElem);
 					}
 				} else {
+					// Clear selection when clicking normally
+					this.clearCommitSelection();
 					this.loadCommitDetails(eventElem);
 				}
 			}
@@ -3374,6 +3469,9 @@ window.addEventListener('load', () => {
 				break;
 			case 'revertCommit':
 				refreshOrDisplayError(msg.error, 'Unable to Revert Commit');
+				break;
+			case 'squashCommits':
+				refreshOrDisplayError(msg.error, 'Unable to Squash Commits');
 				break;
 			case 'setGlobalViewState':
 				finishOrDisplayError(msg.error, 'Unable to save the Global View State');

--- a/web/styles/main.css
+++ b/web/styles/main.css
@@ -671,6 +671,14 @@ body.vscode-high-contrast #commitTable tr.commit.findCurrentCommit{
 	outline-style:dotted;
 }
 
+#commitTable tr.commit.commitSelected {
+	background-color:rgba(0,123,255,0.2);
+	border-left:3px solid var(--vscode-focusBorder, #007ACC);
+}
+#commitTable tr.commit.commitSelected:hover, #commitTable tr.commit.commitSelected.contextMenuActive {
+	background-color:rgba(0,123,255,0.3);
+}
+
 #commitTable tr.commit.mute.commitDetailsOpen td.text,
 #commitTable tr.commit.mute.commitDetailsOpen span.description .text,
 #commitTable tr.commit.mute.findCurrentCommit td.text,


### PR DESCRIPTION
This pull request introduces a new feature allowing users to squash multiple commits into one via the Git Graph extension. It includes backend support for the squash operation and frontend enhancements to enable multi-select commit management in the UI. The key changes are grouped into backend functionality updates, frontend UI enhancements, and styling adjustments.

### Backend Functionality Updates:
* Added a new method `squashCommits` in `DataSource` to handle the git squash operation, including resetting the repository and creating a new squashed commit. (`src/dataSource.ts`, [src/dataSource.tsR1100-R1128](diffhunk://#diff-ddaddfdd6c10f54292c6cb84598c8bf76f0cf7f5bf9e6cf30f66d0b3bf7c8dc3R1100-R1128))
* Introduced new request and response types (`RequestSquashCommits` and `ResponseSquashCommits`) to facilitate communication between the frontend and backend for the squash operation. (`src/types.ts`, [[1]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR823-R831) [[2]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR1313) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR1377)
* Updated `GitGraphView` to handle the new `squashCommits` command and send appropriate messages to the backend. (`src/gitGraphView.ts`, [src/gitGraphView.tsR373-R378](diffhunk://#diff-bd1437701abf06739ceb07c9084bd62542f956756f74394d755a72e1f60539faR373-R378))

### Frontend UI Enhancements:
* Added multi-select commit management functionality, including methods to toggle selection, clear selections, check contiguity, and initiate the squash operation via a confirmation dialog. (`web/main.ts`, [[1]](diffhunk://#diff-906ac49c9d75940373ab1c2c0c3549e53cd8905053385a1bbd2e1d5a30ae5d7eR778-R851) [[2]](diffhunk://#diff-906ac49c9d75940373ab1c2c0c3549e53cd8905053385a1bbd2e1d5a30ae5d7eL1102-R1188) [[3]](diffhunk://#diff-906ac49c9d75940373ab1c2c0c3549e53cd8905053385a1bbd2e1d5a30ae5d7eL2219-R2329)
* Enhanced the context menu to display a "Squash Selected Commits" option when multiple contiguous commits are selected. (`web/main.ts`, [web/main.tsL1102-R1188](diffhunk://#diff-906ac49c9d75940373ab1c2c0c3549e53cd8905053385a1bbd2e1d5a30ae5d7eL1102-R1188))

### Styling Adjustments:
* Introduced new CSS styles to visually indicate selected commits in the commit table, including hover and active states. (`web/styles/main.css`, [web/styles/main.cssR674-R681](diffhunk://#diff-7ce463b188570934d933ddec3ece280ac4ddbec0c7fa690c65e6910234de2638R674-R681))Issue Number / Link: (If this is a minor change, then an issue does not need to be created and this line can be deleted.)

Summary of problem: Select multiple commits to right-click and squash commit.
